### PR TITLE
Fix sparkctl configure using wrong binary paths

### DIFF
--- a/src/sparkctl/cli/sparkctl.py
+++ b/src/sparkctl/cli/sparkctl.py
@@ -1,7 +1,7 @@
 import sys
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import rich_click as click
 import toml
@@ -10,6 +10,7 @@ from loguru import logger
 from sparkctl.config import (
     DEFAULT_SETTINGS_FILENAME,
     RUNTIME,
+    get_binaries,
     sparkctl_settings,
 )
 from sparkctl.cluster_manager import ClusterManager
@@ -337,46 +338,46 @@ def configure(
     if python_path is None and use_current_python:
         logger.info("Use the current Python executable for Spark workers.")
         python_path = sys.executable
-    config = SparkConfig(
-        binaries=BinaryLocations(
-            spark_path=sparkctl_settings.binaries.spark_path,
-            java_path=sparkctl_settings.binaries.java_path,
-            hadoop_path=sparkctl_settings.binaries.get("hadoop_path"),
-            hive_tarball=sparkctl_settings.binaries.get("hive_tarball"),
-            postgresql_jar_file=sparkctl_settings.binaries.get("postgresql_jar_file"),
-        ),
-        runtime=SparkRuntimeParams(
-            executor_cores=executor_cores,
-            executor_memory_gb=executor_memory_gb,
-            driver_memory_gb=driver_memory_gb,
-            node_memory_overhead_gb=node_memory_overhead_gb,
-            enable_dynamic_allocation=dynamic_allocation,
-            shuffle_partition_multiplier=shuffle_partition_multiplier,
-            spark_defaults_template_file=spark_defaults_template_file,
-            use_local_storage=local_storage,
-            start_connect_server=connect_server,
-            start_history_server=history_server,
-            start_thrift_server=thrift_server,
-            spark_log_level=spark_log_level,
-            enable_hive_metastore=hive_metastore,
-            enable_postgres_hive_metastore=postgres_hive_metastore,
-            python_path=python_path,
-        ),
-        directories=RuntimeDirectories(
-            base=directory,
-            spark_scratch=spark_scratch,
-            metastore_dir=metastore_dir,
-        ),
-        compute=sparkctl_settings.get("compute", {"environment": "slurm"}),
-    )
-    config.resource_monitor.enabled = resource_monitor
-    res = handle_sparkctl_exception(ctx, _configure, config, start)
+
+    def build_config() -> SparkConfig:
+        # Build inside the handled scope so that a missing binaries configuration
+        # (raised by get_binaries) is reported cleanly rather than as a traceback.
+        config = SparkConfig(
+            binaries=get_binaries(),
+            runtime=SparkRuntimeParams(
+                executor_cores=executor_cores,
+                executor_memory_gb=executor_memory_gb,
+                driver_memory_gb=driver_memory_gb,
+                node_memory_overhead_gb=node_memory_overhead_gb,
+                enable_dynamic_allocation=dynamic_allocation,
+                shuffle_partition_multiplier=shuffle_partition_multiplier,
+                spark_defaults_template_file=spark_defaults_template_file,
+                use_local_storage=local_storage,
+                start_connect_server=connect_server,
+                start_history_server=history_server,
+                start_thrift_server=thrift_server,
+                spark_log_level=spark_log_level,
+                enable_hive_metastore=hive_metastore,
+                enable_postgres_hive_metastore=postgres_hive_metastore,
+                python_path=python_path,
+            ),
+            directories=RuntimeDirectories(
+                base=directory,
+                spark_scratch=spark_scratch,
+                metastore_dir=metastore_dir,
+            ),
+            compute=sparkctl_settings.get("compute", {"environment": "slurm"}),
+        )
+        config.resource_monitor.enabled = resource_monitor
+        return config
+
+    res = handle_sparkctl_exception(ctx, _configure, build_config, start)
     if res[1] != 0:
         ctx.exit(res[1])
 
 
-def _configure(config: SparkConfig, start: bool) -> ClusterManager:
-    mgr = ClusterManager(config)
+def _configure(build_config: Callable[[], SparkConfig], start: bool) -> ClusterManager:
+    mgr = ClusterManager(build_config())
     mgr.configure()
     if start:
         mgr.start()

--- a/src/sparkctl/config.py
+++ b/src/sparkctl/config.py
@@ -4,16 +4,10 @@ from pathlib import Path
 from dynaconf import Dynaconf, Validator  # type: ignore
 from rich import print
 
+from sparkctl.exceptions import InvalidConfiguration
 from sparkctl.models import BinaryLocations, SparkRuntimeParams, SparkConfig
 
 DEFAULT_SETTINGS_FILENAME = ".sparkctl.toml"
-BINARIES = {
-    "spark_path": Path("/datasets/images/apache_spark/spark-4.0.0-bin-hadoop3"),
-    "java_path": Path("/datasets/images/apache_spark/jdk-21.0.7"),
-    "hadoop_path": Path("/datasets/images/apache_spark/hadoop-3.4.1"),
-    "hive_tarball": Path("/datasets/images/apache_spark/apache-hive-4.0.1-bin.tar.gz"),
-    "postgresql_jar_file": Path("/datasets/images/apache_spark/postgresql-42.7.4.jar"),
-}
 RUNTIME = {
     "executor_cores": SparkRuntimeParams.model_fields["executor_cores"].default,
     "executor_memory_gb": SparkRuntimeParams.model_fields["executor_memory_gb"].default,
@@ -46,10 +40,20 @@ APP = {
 sparkctl_settings = Dynaconf(
     envvar_prefix="SPARKCTL",
     settings_files=[
-        DEFAULT_SETTINGS_FILENAME,
+        # default-config writes to the home directory by default, so load that file
+        # explicitly with an absolute path. A relative path would only be found when running
+        # from $HOME because Dynaconf resolves relative settings files against its root_path
+        # (the first file's directory), not $HOME.
+        Path.home() / DEFAULT_SETTINGS_FILENAME,
+        # Allow a project-local file in the current working directory to override the home
+        # settings. This must also be absolute for the same root_path reason as above.
+        Path.cwd() / DEFAULT_SETTINGS_FILENAME,
     ],
     validators=[
-        Validator("BINARIES", default=BinaryLocations(**BINARIES).model_dump(mode="json")),
+        # There is intentionally no default for BINARIES. Binary paths are environment-specific
+        # and must come from the user's settings file (created by `sparkctl default-config`). A
+        # built-in default would silently produce a config for the wrong environment whenever the
+        # settings file is missing or not found.
         Validator("RUNTIME", default=SparkRuntimeParams(**RUNTIME).model_dump(mode="json")),
         Validator("COMPUTE", default=ComputeParams().model_dump(mode="json")),
         Validator("APP", default=AppParams().model_dump(mode="json")),
@@ -57,10 +61,30 @@ sparkctl_settings = Dynaconf(
 )
 
 
+def get_binaries() -> BinaryLocations:
+    """Return the binary locations from the user's settings file.
+
+    Raises
+    ------
+    InvalidConfiguration
+        Raised if no settings file with binary paths has been loaded.
+    """
+    binaries = sparkctl_settings.get("binaries")
+    if not binaries:
+        settings_file = Path.home() / DEFAULT_SETTINGS_FILENAME
+        msg = (
+            "No sparkctl binary paths are configured. Run `sparkctl default-config` to create a "
+            f"settings file at {settings_file} (or in the current directory) before running this "
+            "command."
+        )
+        raise InvalidConfiguration(msg)
+    return BinaryLocations(**binaries)
+
+
 def make_default_spark_config() -> SparkConfig:
     """Return a SparkConfig created from the user's config file."""
     return SparkConfig(
-        binaries=BinaryLocations(**sparkctl_settings.binaries),
+        binaries=get_binaries(),
         runtime=SparkRuntimeParams(**sparkctl_settings.runtime),
         compute=ComputeParams(**sparkctl_settings.compute),
     )


### PR DESCRIPTION
## Problem

Running `sparkctl configure` on an HPC other than the one whose paths are baked into the code produced a `config.json` with the wrong (Kestrel) binary paths, instead of the paths configured via `sparkctl default-config`.

Two compounding bugs:

1. **Settings file not found from non-`$HOME` directories.** `default-config` writes the settings file to `$HOME` by default, but `config.py` configured Dynaconf with a *relative* filename. Dynaconf only searches the current working directory and its ancestors, so `~/.sparkctl.toml` was found only when running from `$HOME` or a descendant. On an HPC scratch/projects mount (a different filesystem, not under `$HOME`), nothing was found.

2. **Silent fallback to hard-coded Kestrel defaults.** When no settings file was found, Dynaconf fell back to the hard-coded Kestrel paths in the `BINARIES` defaults — silently producing a valid-looking config for the wrong environment.

## Changes

- Load the home settings file via an **absolute** path, plus an absolute cwd path so a project-local `.sparkctl.toml` can still override it. (Absolute paths are required because Dynaconf resolves relative settings files against `root_path`, not `$HOME`.)
- **Remove the hard-coded Kestrel `BINARIES` defaults and their validator entirely.** Binary paths are environment-specific and must come from the user's settings file. `configure` now fails loudly via `InvalidConfiguration` with a message to run `sparkctl default-config`, instead of silently using the wrong paths.

## Behavior change

Anyone (perhaps unknowingly) relying on the built-in Kestrel defaults will now get a clear error until they run `sparkctl default-config`. This matches what the installation docs already describe (default-config is a required one-time setup step), so no doc change is needed — worth a changelog note.

## Testing

Verified manually (full `pytest` couldn't run locally — `conftest.py` downloads Spark/Hive tarballs and the sandbox blocks network):
- No settings file → `configure` exits 1 with the actionable error message.
- `default-config` → read-back via `get_binaries()` works from a working directory outside `$HOME` (the original bug).
- A project-local `.sparkctl.toml` still overrides the home file.
- ruff, ruff-format, and mypy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)