### PR TITLE
Launch Spark workers with srun in Slurm environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         python -m pip install ".[dev]"
     - name: Run pytest with coverage
       run: |
-        pytest -v --cov --cov-report=xml
+        pytest -v -m "not integration" --cov --cov-report=xml
     - name: codecov
       uses: codecov/codecov-action@v4.2.0
       if: ${{ matrix.os == env.DEFAULT_OS && matrix.python-version == env.DEFAULT_PYTHON  }}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,26 @@ support.
 
 Contributions are welcome.
 
+## Development
+Install the package with its development dependencies:
+```console
+$ pip install -e ".[dev]"
+```
+
+Run the unit tests. These are fast, require no special resources, and are what CI runs:
+```console
+$ pytest -m "not integration"
+```
+
+The integration tests download a real Spark and Java distribution into `tests/data/` and start a
+real single-node Spark cluster, so they are slower and require network access and sufficient
+memory. They are excluded from CI; run them locally with:
+```console
+$ pytest -m integration
+```
+
+Run the complete suite (unit and integration tests) with `pytest`.
+
 ## License
 sparkctl is released under a BSD 3-Clause [license](https://github.com/NatLabRockies/sparkctl/blob/main/LICENSE).
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ support.
 Contributions are welcome.
 
 ## License
-sparkctl is released under a BSD 3-Clause [license](https://github.com/NREL/sparkctl/blob/main/LICENSE).
+sparkctl is released under a BSD 3-Clause [license](https://github.com/NatLabRockies/sparkctl/blob/main/LICENSE).
 
 ## Software Record
 This package is developed under NLR Software Record SWR-25-109.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -52,6 +52,20 @@ environment variable before running your application:
 $ export PYSPARK_PYTHON=$(which python)
 ```
 
+### My workers fail to find a shared library (e.g. `libpython3.11.so`).
+
+This happens when the Python (or other dependency) you loaded before allocating nodes relies on an
+environment that is not present on the worker nodes by default. In a Slurm environment, sparkctl
+launches workers with `srun`, which forwards your full submission environment — environment
+modules, virtual environments, and `LD_LIBRARY_PATH` — to the worker nodes. This usually resolves
+such errors without extra configuration.
+
+If your site's Slurm configuration does not work with sparkctl's `srun` invocation, you can fall
+back to launching workers over `ssh` by setting `use_srun = false` in the `[compute]` section of
+your `~/.sparkctl.toml`. Note that `ssh` does not forward your environment, so you may then need to
+export the relevant variables yourself, for example through `spark-env.sh` in the generated
+`./conf/` directory.
+
 ### I'm getting an error about mismatched Spark versions.
 
 If you are running pyspark/spark-submit after installing via `pip install sparkctl[pyspark]`,

--- a/docs/how_tos/debugging/index.md
+++ b/docs/how_tos/debugging/index.md
@@ -173,7 +173,7 @@ $ htop
 ```
 
 ### Automated resource monitoring
-sparkctl integrates with [rmon](https://github.com/NREL/resource_monitor) to collect resource
+sparkctl integrates with [rmon](https://github.com/NatLabRockies/resource_monitor) to collect resource
 utilization stats from all compute nodes in your cluster. You can enable this monitoring when
 you configure the cluster:
 

--- a/docs/how_tos/execution/resource_monitoring.md
+++ b/docs/how_tos/execution/resource_monitoring.md
@@ -1,6 +1,6 @@
 # How to to monitor Spark resource utilization
 
-sparkctl integrates with [rmon](https://github.com/NREL/resource_monitor) to monitor CPU, memory,
+sparkctl integrates with [rmon](https://github.com/NatLabRockies/resource_monitor) to monitor CPU, memory,
 disk, and network utilization of Spark.
 
 This page shows how to enable it.

--- a/docs/how_tos/getting_started/deploy_sparkctl.md
+++ b/docs/how_tos/getting_started/deploy_sparkctl.md
@@ -73,7 +73,7 @@ $ sparkctl configure --start
 
 A ready-to-deploy modulefile (TCL and Lua flavors), an example shared settings
 file, and step-by-step instructions are provided in the
-[`hpc/environment_module`](https://github.com/NREL/sparkctl/tree/main/hpc/environment_module)
+[`hpc/environment_module`](https://github.com/NatLabRockies/sparkctl/tree/main/hpc/environment_module)
 directory of the repository. The module activates the shared virtual
 environment, sets `SPARKCTL_SETTINGS_FILE`, and puts `spark-submit`/`pyspark` on
 the user's `PATH`.

--- a/docs/how_tos/getting_started/deploy_sparkctl.md
+++ b/docs/how_tos/getting_started/deploy_sparkctl.md
@@ -27,14 +27,20 @@ Here is an example filesystem layout:
 ```
 
 ## URLs
-Download locations will vary over time. Here is a set of URLs with software tested with Apache
-Spark v4.1.2:
+Download locations will vary over time. Here is a set of permanent links to the specific software
+versions tested with Apache Spark v4.1.2:
 
-- https://dlcdn.apache.org/spark/spark-4.1.2/spark-4.1.2-bin-hadoop3.tgz
-- https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.tar.gz
+- https://archive.apache.org/dist/spark/spark-4.1.2/spark-4.1.2-bin-hadoop3.tgz
+- https://download.oracle.com/java/21/archive/jdk-21.0.7_linux-x64_bin.tar.gz
 - https://archive.apache.org/dist/hadoop/common/hadoop-3.4.1/hadoop-3.4.1.tar.gz
-- https://downloads.apache.org/hive/hive-4.0.1/apache-hive-4.0.1-bin.tar.gz
+- https://archive.apache.org/dist/hive/hive-4.0.1/apache-hive-4.0.1-bin.tar.gz
 - https://jdbc.postgresql.org/download/postgresql-42.7.4.jar
+
+To use a different version, substitute the version number in the path. For the Apache projects, use
+`archive.apache.org/dist/...`, which permanently hosts every release. The mirror hosts
+(`downloads.apache.org` and `dlcdn.apache.org`) and Oracle's `java/21/latest/` path only serve the
+current release, so a version-specific URL on those hosts returns a 404 once a newer version is
+published.
 
 ## sparkctl configuration file
 This command will create a default sparkctl configuration file given this filesystem layout:

--- a/docs/how_tos/getting_started/deploy_sparkctl.md
+++ b/docs/how_tos/getting_started/deploy_sparkctl.md
@@ -19,7 +19,7 @@ Here is an example filesystem layout:
 
 ```
 /datasets/images/apache_spark
-├── apache-hive-4.0.1-bin.tar.gz
+├── apache-hive-4.2.0-bin.tar.gz
 ├── hadoop-3.4.1/
 ├── jdk-21.0.7/
 ├── postgresql-42.7.4.jar
@@ -33,7 +33,7 @@ versions tested with Apache Spark v4.1.2:
 - https://archive.apache.org/dist/spark/spark-4.1.2/spark-4.1.2-bin-hadoop3.tgz
 - https://download.oracle.com/java/21/archive/jdk-21.0.7_linux-x64_bin.tar.gz
 - https://archive.apache.org/dist/hadoop/common/hadoop-3.4.1/hadoop-3.4.1.tar.gz
-- https://archive.apache.org/dist/hive/hive-4.0.1/apache-hive-4.0.1-bin.tar.gz
+- https://archive.apache.org/dist/hive/hive-4.2.0/apache-hive-4.2.0-bin.tar.gz
 - https://jdbc.postgresql.org/download/postgresql-42.7.4.jar
 
 To use a different version, substitute the version number in the path. For the Apache projects, use
@@ -49,7 +49,7 @@ $ sparkctl default-config \
     /datasets/images/apache_spark/spark-4.1.2-bin-hadoop3 \
     /datasets/images/apache_spark/jdk-21.0.7 \
     --hadoop-path /datasets/images/apache_spark/hadoop-3.4.1 \
-    --hive-tarball /datasets/images/apache_spark/apache-hive-4.0.1-bin.tar.gz \
+    --hive-tarball /datasets/images/apache_spark/apache-hive-4.2.0-bin.tar.gz \
     --postgresql-jar-file /datasets/images/apache_spark/postgresql-42.7.4.jar \
     --compute-environment slurm
 ```

--- a/docs/how_tos/getting_started/installation.md
+++ b/docs/how_tos/getting_started/installation.md
@@ -41,7 +41,7 @@
 4. Optional, install from the main branch (or substitute another branch or tag).
 
    ```console
-   $ pip install git+https://github.com/NREL/sparkctl.git@main
+   $ pip install git+https://github.com/NatLabRockies/sparkctl.git@main
    ```
 
 5. Create a one-time sparkctl default configuration file. The parameters will vary based on your

--- a/docs/reference/hpc/kestrel.md
+++ b/docs/reference/hpc/kestrel.md
@@ -7,7 +7,7 @@ This page contains information specific to Kestrel that users must consider.
 Spark is installed on Kestrel. Use these locations when your configure your environment.
 ```
 /datasets/images/apache_spark
-├── apache-hive-4.0.1-bin.tar.gz
+├── apache-hive-4.2.0-bin.tar.gz
 ├── hadoop-3.4.1/
 ├── jdk-21.0.7/
 ├── postgresql-42.7.4.jar
@@ -19,7 +19,7 @@ $ sparkctl default-config \
     /datasets/images/apache_spark/spark-4.1.2-bin-hadoop3 \
     /datasets/images/apache_spark/jdk-21.0.7 \
     --hadoop-path /datasets/images/apache_spark/hadoop-3.4.1 \
-    --hive-tarball /datasets/images/apache_spark/apache-hive-4.0.1-bin.tar.gz \
+    --hive-tarball /datasets/images/apache_spark/apache-hive-4.2.0-bin.tar.gz \
     --postgresql-jar-file /datasets/images/apache_spark/postgresql-42.7.4.jar \
     --compute-environment slurm
 ```

--- a/hpc/environment_module/sparkctl.toml
+++ b/hpc/environment_module/sparkctl.toml
@@ -18,7 +18,7 @@ spark_path = "/datasets/images/spark/spark-4.1.2-bin-hadoop3"
 java_path = "/datasets/images/spark/jdk-21.0.7+6"
 # Optional. Remove or leave commented if not deployed.
 # hadoop_path = "/datasets/images/spark/hadoop-3.4.1"
-# hive_tarball = "/datasets/images/spark/apache-hive-4.0.1-bin.tar.gz"
+# hive_tarball = "/datasets/images/spark/apache-hive-4.2.0-bin.tar.gz"
 # postgresql_jar_file = "/datasets/images/spark/postgresql-42.7.4.jar"
 
 [compute]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,9 @@ minversion = "6.0"
 addopts = "-ra"
 testpaths = ["tests"]
 norecursedirs = ["tests/data"]
+markers = [
+    "integration: tests that download real Spark/Java binaries or start a real Spark cluster; excluded from CI, run locally with -m integration",
+]
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,9 @@ dev = [
 ]
 
 [project.urls]
-Documentation = "https://github.com/NREL/sparkctl#readme"
-Issues = "https://github.com/NREL/sparkctl/issues"
-Source = "https://github.com/NREL/sparkctl"
+Documentation = "https://github.com/NatLabRockies/sparkctl#readme"
+Issues = "https://github.com/NatLabRockies/sparkctl/issues"
+Source = "https://github.com/NatLabRockies/sparkctl"
 
 [project.scripts]
 sparkctl = "sparkctl.cli.sparkctl:cli"

--- a/src/sparkctl/cli/sparkctl.py
+++ b/src/sparkctl/cli/sparkctl.py
@@ -79,7 +79,8 @@ $ sparkctl default-config ~/apache-spark/spark-4.1.2-bin-hadoop3 ~/jdk-21.0.8 -e
 @click.option(
     "-e",
     "--compute-environment",
-    type=click.Choice([x.value for x in ComputeEnvironment]),
+    # FAKE is intended for tests only, so it is not offered as a user-facing choice.
+    type=click.Choice([x.value for x in ComputeEnvironment if x != ComputeEnvironment.FAKE]),
     default=ComputeEnvironment.SLURM.value,
     help="Compute environment",
     callback=lambda *x: ComputeEnvironment(x[2]),

--- a/src/sparkctl/cluster_manager.py
+++ b/src/sparkctl/cluster_manager.py
@@ -302,7 +302,9 @@ class ClusterManager:
             runner.start_worker_process(worker_memory_gb)
             tracker.started_workers = True
         else:
-            runner.start_worker_processes(workers, worker_memory_gb)
+            runner.start_worker_processes(
+                workers, worker_memory_gb, num_cpus_per_worker=self._intf.get_worker_num_cpus()
+            )
             tracker.started_workers = True
         logger.info("Spark worker memory = {} GB", worker_memory_gb)
 

--- a/src/sparkctl/cluster_manager.py
+++ b/src/sparkctl/cluster_manager.py
@@ -434,7 +434,9 @@ spark.worker.cleanup.enabled = true
         # Leave one CPU for OS and management software.
         worker_num_cpus -= 1
 
-        min_executors_per_node = worker_num_cpus // self._config.runtime.executor_cores
+        # Use at least one executor per node even when the node has fewer CPUs than
+        # executor_cores (e.g. a small CI runner or laptop), which would otherwise divide by zero.
+        min_executors_per_node = max(1, worker_num_cpus // self._config.runtime.executor_cores)
         if self._config.runtime.executor_memory_gb is None:
             executor_memory_gb = worker_memory_gb // min_executors_per_node
         else:
@@ -446,7 +448,7 @@ spark.worker.cleanup.enabled = true
             )
             raise InvalidConfiguration(msg)
         executors_by_mem = worker_memory_gb // executor_memory_gb
-        executors_by_cpu = worker_num_cpus // self._config.runtime.executor_cores
+        executors_by_cpu = min_executors_per_node
         if executors_by_cpu <= executors_by_mem:
             executors_per_node = executors_by_cpu
         else:

--- a/src/sparkctl/compute_interface_factory.py
+++ b/src/sparkctl/compute_interface_factory.py
@@ -1,4 +1,5 @@
 from sparkctl.compute_interface import ComputeInterface
+from sparkctl.fake_compute import FakeCompute
 from sparkctl.models import ComputeEnvironment, SparkConfig
 from sparkctl.native_compute import NativeCompute
 from sparkctl.slurm_compute import SlurmCompute
@@ -11,6 +12,8 @@ def make_compute_interface(config: SparkConfig) -> ComputeInterface:
             return SlurmCompute(config)
         case ComputeEnvironment.NATIVE:
             return NativeCompute(config)
+        case ComputeEnvironment.FAKE:
+            return FakeCompute(config)
         case _:
             msg = f"{config.environment=} is not supported"
             raise NotImplementedError(msg)

--- a/src/sparkctl/compute_interface_factory.py
+++ b/src/sparkctl/compute_interface_factory.py
@@ -15,5 +15,5 @@ def make_compute_interface(config: SparkConfig) -> ComputeInterface:
         case ComputeEnvironment.FAKE:
             return FakeCompute(config)
         case _:
-            msg = f"{config.environment=} is not supported"
+            msg = f"{config.compute.environment=} is not supported"
             raise NotImplementedError(msg)

--- a/src/sparkctl/exceptions.py
+++ b/src/sparkctl/exceptions.py
@@ -8,3 +8,7 @@ class InvalidConfiguration(SparkctlBaseException):
 
 class OperationNotAllowed(SparkctlBaseException):
     """Raised when a user performs an invalid operation."""
+
+
+class ExecutionError(SparkctlBaseException):
+    """Raised when an external command fails."""

--- a/src/sparkctl/fake_compute.py
+++ b/src/sparkctl/fake_compute.py
@@ -1,0 +1,45 @@
+import tempfile
+from pathlib import Path
+from socket import gethostname
+
+from sparkctl.compute_interface import ComputeInterface
+
+
+class FakeCompute(ComputeInterface):
+    """Provides a single-node compute interface with deterministic resources.
+
+    This is intended for testing so that results do not depend on the resources of the
+    machine running the tests.
+    """
+
+    def get_node_memory_overhead_gb(
+        self, driver_memory_gb: int, node_memory_overhead_gb: int
+    ) -> int:
+        return driver_memory_gb + self._config.runtime.node_memory_overhead_gb
+
+    def get_num_workers(self) -> int:
+        return 1
+
+    def get_node_names(self) -> list[str]:
+        return [gethostname()]
+
+    def get_scratch_dir(self) -> Path:
+        return Path(tempfile.gettempdir())
+
+    def get_worker_node_names(self) -> list[str]:
+        return self.get_node_names()
+
+    def get_worker_memory_gb(self) -> int:
+        return 32
+
+    def get_worker_num_cpus(self) -> int:
+        return 12
+
+    def is_heterogeneous_slurm_job(self) -> bool:
+        return False
+
+    def is_worker_node(self, node_name: str) -> bool:
+        return True
+
+    def run_checks(self) -> None:
+        pass

--- a/src/sparkctl/models.py
+++ b/src/sparkctl/models.py
@@ -245,6 +245,14 @@ class ResourceMonitorConfig(SparkctlBaseModel):
 
 class ComputeParams(SparkctlBaseModel):
     environment: ComputeEnvironment = ComputeEnvironment.SLURM
+    use_srun: bool = Field(
+        default=True,
+        description="In a Slurm environment, launch Spark workers with srun instead of ssh. "
+        "srun forwards the full submission environment (modules, virtual environments, "
+        "LD_LIBRARY_PATH) to the worker nodes. Set to false to fall back to ssh if a site's "
+        "Slurm configuration does not work with sparkctl's srun invocation. Has no effect in a "
+        "native environment.",
+    )
     postgres: PostgresScripts = PostgresScripts()
 
 

--- a/src/sparkctl/models.py
+++ b/src/sparkctl/models.py
@@ -197,6 +197,8 @@ class ComputeEnvironment(StrEnum):
     NATIVE = "native"
     # sparkctl detects workers through Slurm environment variables.
     SLURM = "slurm"
+    # Deterministic values for a single-node cluster, used for testing.
+    FAKE = "fake"
 
 
 class PostgresScripts(SparkctlBaseModel):

--- a/src/sparkctl/spark_process_runner.py
+++ b/src/sparkctl/spark_process_runner.py
@@ -129,6 +129,10 @@ class SparkProcessRunner:
             "srun",
             "--job-name=sparkctl-worker",
             "--export=ALL",
+            # Do not connect the worker task's stdin to this process's stdin. Otherwise this
+            # long-lived background srun competes with the interactive shell for the terminal
+            # and steals keystrokes.
+            "--input=none",
             *self._srun_node_args(workers),
             f"--output={log_dir}/spark-worker-%N.out",
         ]
@@ -138,7 +142,11 @@ class SparkProcessRunner:
         logger.info("Start Spark workers: {}", " ".join(cmd))
         with open(self._get_srun_log_file(), "w", encoding="utf-8") as f_out:
             proc = subprocess.Popen(
-                cmd, stdout=f_out, stderr=subprocess.STDOUT, start_new_session=True
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=f_out,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
             )
         # The job step must stay alive for the lifetime of the workers, so srun runs in
         # the background and tmp_script is not deleted here. configure() recreates the
@@ -209,12 +217,14 @@ class SparkProcessRunner:
             "--job-name=sparkctl-stop-rmon",
             "--export=ALL",
             "--overlap",
+            # Do not read from the terminal; see _start_worker_processes_srun.
+            "--input=none",
             *self._srun_node_args(workers),
         ]
         cmd.append(str(tmp_script))
         logger.info("Stop rmon on workers: {}", " ".join(cmd))
         try:
-            proc = subprocess.run(cmd, env=self._get_env())
+            proc = subprocess.run(cmd, stdin=subprocess.DEVNULL, env=self._get_env())
         finally:
             tmp_script.unlink()
         if proc.returncode != 0:

--- a/src/sparkctl/spark_process_runner.py
+++ b/src/sparkctl/spark_process_runner.py
@@ -1,14 +1,17 @@
 import os
 import shlex
 import shutil
+import signal
 import stat
 import subprocess
+import time
 from pathlib import Path
 from typing import Any
 
 from loguru import logger
 
-from sparkctl.models import SparkConfig
+from sparkctl.exceptions import ExecutionError
+from sparkctl.models import ComputeEnvironment, SparkConfig
 
 
 class SparkProcessRunner:
@@ -63,11 +66,16 @@ class SparkProcessRunner:
         finally:
             tmp_script.unlink()
 
-    def start_worker_processes(self, workers: list[str], memory_gb: int) -> None:
+    def start_worker_processes(
+        self, workers: list[str], memory_gb: int, num_cpus_per_worker: int | None = None
+    ) -> None:
         """Start the Spark worker processes."""
+        if self._use_srun():
+            self._start_worker_processes_srun(workers, memory_gb, num_cpus_per_worker)
+            return
+
         # Calling Spark's start-workers.sh doesn't work because there is no way to forward
         # SPARK_CONF_DIR and JAVA_HOME through ssh in their scripts.
-        # In a Slurm environment, we could srun or mpiexec. This works everywhere.
         start_script = self._sbin_cmd("start-worker.sh")
         tmp_script = self._make_start_worker_script(start_script, memory_gb)
         try:
@@ -84,6 +92,9 @@ class SparkProcessRunner:
 
     def stop_worker_processes(self, workers: list[str]) -> int:
         """Stop the Spark workers."""
+        if self._use_srun():
+            return self._stop_worker_processes_srun(workers)
+
         tmp_script = self._make_stop_worker_script(self._config.resource_monitor.enabled)
         ret = 0
         for worker in workers:
@@ -94,6 +105,145 @@ class SparkProcessRunner:
                 ret = proc.returncode
         tmp_script.unlink()
         return ret
+
+    def _use_srun(self) -> bool:
+        if self._config.compute.environment != ComputeEnvironment.SLURM:
+            return False
+        if not self._config.compute.use_srun:
+            logger.info("Launch Spark workers with ssh because compute.use_srun is disabled.")
+            return False
+        return True
+
+    def _start_worker_processes_srun(
+        self, workers: list[str], memory_gb: int, num_cpus_per_worker: int | None
+    ) -> None:
+        # Unlike ssh, srun forwards the full submission environment to the worker nodes
+        # (environment modules, virtual environments, LD_LIBRARY_PATH).
+        tmp_script = self._make_start_worker_script(
+            self._start_worker_cmd(), memory_gb, daemonize=False
+        )
+        log_dir = self._config.directories.spark_scratch.absolute() / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        num_workers = len(workers)
+        cmd = [
+            "srun",
+            "--job-name=sparkctl-worker",
+            "--export=ALL",
+            *self._srun_node_args(workers),
+            f"--output={log_dir}/spark-worker-%N.out",
+        ]
+        if num_cpus_per_worker is not None:
+            cmd.append(f"--cpus-per-task={num_cpus_per_worker}")
+        cmd.append(str(tmp_script))
+        logger.info("Start Spark workers: {}", " ".join(cmd))
+        with open(self._get_srun_log_file(), "w", encoding="utf-8") as f_out:
+            proc = subprocess.Popen(
+                cmd, stdout=f_out, stderr=subprocess.STDOUT, start_new_session=True
+            )
+        # The job step must stay alive for the lifetime of the workers, so srun runs in
+        # the background and tmp_script is not deleted here. configure() recreates the
+        # conf directory on the next run.
+        time.sleep(1)
+        ret = proc.poll()
+        if ret is not None:
+            msg = (
+                f"The srun command that starts Spark workers exited immediately with "
+                f"return code {ret}. See {self._get_srun_log_file()}."
+            )
+            raise ExecutionError(msg)
+        self._get_srun_pid_file().write_text(f"{proc.pid}\n", encoding="utf-8")
+        logger.info(
+            "Started Spark workers on {} node(s) through srun with pid {}",
+            num_workers,
+            proc.pid,
+        )
+
+    def _srun_node_args(self, workers: list[str]) -> list[str]:
+        num_workers = len(workers)
+        args = [
+            f"--nodes={num_workers}",
+            f"--ntasks={num_workers}",
+            "--ntasks-per-node=1",
+        ]
+        if "SLURM_HET_SIZE" in os.environ:
+            # The master node is heterogeneous group 0; the workers are group 1.
+            args.append("--het-group=1")
+        else:
+            args.append(f"--nodelist={','.join(workers)}")
+        return args
+
+    def _stop_worker_processes_srun(self, workers: list[str]) -> int:
+        # rmon runs inside the worker srun job step, so it must be stopped gracefully before
+        # the step is torn down, otherwise it is killed before it can write its stats and plots.
+        ret = 0
+        if self._config.resource_monitor.enabled:
+            ret = self._stop_rmon_srun(workers)
+
+        pid_file = self._get_srun_pid_file()
+        if not pid_file.exists():
+            logger.error("Cannot stop Spark workers: {} does not exist", pid_file)
+            return ret or 1
+        pid = int(pid_file.read_text(encoding="utf-8").strip())
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            logger.info("The srun process running Spark workers has already exited")
+            pid_file.unlink()
+            return ret
+        if self._wait_for_process_exit(pid, timeout_s=30):
+            logger.info("Stopped the srun process running Spark workers")
+            pid_file.unlink()
+            return ret
+        logger.error(
+            "The srun process {} running Spark workers did not exit within the timeout", pid
+        )
+        return ret or 1
+
+    def _stop_rmon_srun(self, workers: list[str]) -> int:
+        tmp_script = self._make_stop_rmon_script()
+        # --overlap is required because the worker srun job step is still holding the
+        # allocation's resources; without it this step would block until the workers exit,
+        # which is the opposite of what we need.
+        cmd = [
+            "srun",
+            "--job-name=sparkctl-stop-rmon",
+            "--export=ALL",
+            "--overlap",
+            *self._srun_node_args(workers),
+        ]
+        cmd.append(str(tmp_script))
+        logger.info("Stop rmon on workers: {}", " ".join(cmd))
+        try:
+            proc = subprocess.run(cmd, env=self._get_env())
+        finally:
+            tmp_script.unlink()
+        if proc.returncode != 0:
+            logger.error("Failed to stop rmon on workers: {}", proc.returncode)
+        return proc.returncode
+
+    @staticmethod
+    def _wait_for_process_exit(pid: int, timeout_s: int) -> bool:
+        for _ in range(timeout_s):
+            try:
+                # Reap the process if it is a child of this process, as happens with
+                # ClusterManager.managed_cluster. Otherwise, it would remain a zombie
+                # and appear to be running in the check below.
+                wpid, _ = os.waitpid(pid, os.WNOHANG)
+                if wpid == pid:
+                    return True
+            except ChildProcessError:
+                try:
+                    os.kill(pid, 0)
+                except ProcessLookupError:
+                    return True
+            time.sleep(1)
+        return False
+
+    def _get_srun_pid_file(self) -> Path:
+        return self._config.directories.base / "srun_workers.pid"
+
+    def _get_srun_log_file(self) -> Path:
+        return self._config.directories.base / "srun_workers.log"
 
     def _start_workers(self, script: str, memory_gb: int | None) -> None:
         cmd = f"{script} {self._url}"
@@ -156,15 +306,25 @@ class SparkProcessRunner:
         self,
         start_script: str,
         memory_gb: int,
+        daemonize: bool = True,
     ) -> Path:
         conf_dir = self._config.directories.get_spark_conf_dir()
         content = f"""#!/bin/bash
 export SPARK_CONF_DIR={conf_dir}
 export JAVA_HOME={self._java_path}
-{start_script} {self._url} -m {memory_gb}g
 """
-        if self._config.resource_monitor.enabled:
-            content += self._get_rmon_commands()
+        worker_cmd = f"{start_script} {self._url} -m {memory_gb}g"
+        if daemonize:
+            content += f"{worker_cmd}\n"
+            if self._config.resource_monitor.enabled:
+                content += self._get_rmon_commands()
+        else:
+            # Slurm kills daemonized processes when the srun job step completes, so keep
+            # the worker in the foreground for the lifetime of the step.
+            content += "export SPARK_NO_DAEMONIZE=true\n"
+            if self._config.resource_monitor.enabled:
+                content += self._get_rmon_commands()
+            content += f"exec {worker_cmd}\n"
         tmp_script = self._conf_dir / "tmp_start_worker.sh"
         tmp_script.write_text(content, encoding="utf-8")
         os.chmod(tmp_script, os.stat(tmp_script).st_mode | stat.S_IXUSR)
@@ -193,17 +353,35 @@ export JAVA_HOME={self._java_path}
 {self._stop_worker_cmd()}
 """
         if kill_rmon:
-            content += f"""
-rmon_pid_file={self._config.directories.base}/rmon_$(hostname).pid
-if [ -f $rmon_pid_file ]; then
-    pid=$(cat $rmon_pid_file)
-    if kill -0 "$pid" 2>/dev/null; then
-        kill -TERM $pid
-    fi
-    rm $rmon_pid_file
-fi
-"""
+            content += self._get_rmon_stop_snippet()
         tmp_script = self._conf_dir / "tmp_stop_worker.sh"
         tmp_script.write_text(content, encoding="utf-8")
         os.chmod(tmp_script, os.stat(tmp_script).st_mode | stat.S_IXUSR)
         return tmp_script
+
+    def _make_stop_rmon_script(self) -> Path:
+        content = f"""#!/bin/bash
+{self._get_rmon_stop_snippet()}"""
+        tmp_script = self._conf_dir / "tmp_stop_rmon.sh"
+        tmp_script.write_text(content, encoding="utf-8")
+        os.chmod(tmp_script, os.stat(tmp_script).st_mode | stat.S_IXUSR)
+        return tmp_script
+
+    def _get_rmon_stop_snippet(self) -> str:
+        # Send SIGTERM to the rmon process recorded on this node, then wait for it to exit so
+        # that it can flush its stats and write its plots. This matters most on the srun path,
+        # where the worker job step (and thus rmon) is torn down immediately afterward.
+        return f"""
+rmon_pid_file={self._config.directories.base}/rmon_$(hostname).pid
+if [ -f "$rmon_pid_file" ]; then
+    pid=$(cat "$rmon_pid_file")
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -TERM "$pid"
+        for _ in $(seq 1 30); do
+            kill -0 "$pid" 2>/dev/null || break
+            sleep 1
+        done
+    fi
+    rm -f "$rmon_pid_file"
+fi
+"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from sparkctl.models import ComputeEnvironment
 
 SPARK_DIR_NAME = "spark-4.1.2-bin-hadoop3"
 SPARK_GZ_NAME = f"{SPARK_DIR_NAME}.tgz"
-SPARK_URL = f"https://dlcdn.apache.org/spark/spark-4.1.2/{SPARK_GZ_NAME}"
+SPARK_URL = f"https://archive.apache.org/dist/spark/spark-4.1.2/{SPARK_GZ_NAME}"
 SPARK_DIR_GZ = Path("tests") / "data" / SPARK_GZ_NAME
 SPARK_DIR = Path("tests") / "data" / SPARK_DIR_NAME
 
@@ -28,7 +28,7 @@ HADOOP_DIR = Path("tests") / "data" / HADOOP_DIR_NAME
 
 HIVE_DIR_NAME = "apache-hive-4.0.1-bin"
 HIVE_GZ_NAME = f"{HIVE_DIR_NAME}.tar.gz"
-HIVE_URL = f"https://downloads.apache.org/hive/hive-4.0.1/{HIVE_GZ_NAME}"
+HIVE_URL = f"https://archive.apache.org/dist/hive/hive-4.0.1/{HIVE_GZ_NAME}"
 HIVE_DIR_GZ = Path("tests") / "data" / HIVE_GZ_NAME
 HIVE_DIR = Path("tests") / "data" / HIVE_DIR_NAME
 
@@ -63,14 +63,14 @@ TARBALLS: list[dict[str, Any]] = [
 
 if sys.platform == "linux":
     JAVA_DIR_NAME = "jdk-21.0.7"
-    JAVA_GZ_NAME = "jdk-21_linux-x64_bin.tar.gz"
-    JAVA_URL = f"https://download.oracle.com/java/21/latest/{JAVA_GZ_NAME}"
+    JAVA_GZ_NAME = "jdk-21.0.7_linux-x64_bin.tar.gz"
+    JAVA_URL = f"https://download.oracle.com/java/21/archive/{JAVA_GZ_NAME}"
     JAVA_DIR_GZ = Path("tests") / "data" / JAVA_GZ_NAME
     JAVA_DIR = Path("tests") / "data" / JAVA_DIR_NAME
 elif sys.platform == "darwin":
     JAVA_DIR_NAME = "jdk-21.0.7.jdk"
-    JAVA_GZ_NAME = "jdk-21_macos-aarch64_bin.tar.gz"
-    JAVA_URL = f"https://download.oracle.com/java/21/latest/{JAVA_GZ_NAME}"
+    JAVA_GZ_NAME = "jdk-21.0.7_macos-aarch64_bin.tar.gz"
+    JAVA_URL = f"https://download.oracle.com/java/21/archive/{JAVA_GZ_NAME}"
     JAVA_DIR_GZ = Path("tests") / "data" / JAVA_GZ_NAME
     JAVA_DIR = Path("tests") / "data" / JAVA_DIR_NAME
 else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,9 @@ from typing import Any
 
 import pytest
 import requests
-import toml
 
 from sparkctl.cli.sparkctl import _create_default_config
-from sparkctl.config import DEFAULT_SETTINGS_FILENAME
+from sparkctl.config import sparkctl_settings
 from sparkctl.models import ComputeEnvironment
 
 
@@ -90,6 +89,12 @@ TARBALLS.append(
 
 
 def pytest_sessionstart(session):
+    # The large Spark/Java/Hadoop/Hive downloads are only needed by the integration tests
+    # (those that download real binaries or start a real cluster). Skip them when integration
+    # tests are deselected, such as the unit-only run in CI (pytest -m "not integration").
+    if "not integration" in (session.config.option.markexpr or ""):
+        return
+
     base_dir = Path("tests") / "data"
     base_dir.mkdir(exist_ok=True)
     in_ci = os.getenv("CI", "false") == "true"
@@ -139,7 +144,7 @@ def extract_tarball(src_file: Path, extract_dir: Path) -> None:
 
 @pytest.fixture
 def setup_local_env(tmp_path):
-    config = _create_default_config(SPARK_DIR, JAVA_DIR, tmp_path, ComputeEnvironment.NATIVE)
+    config = _create_default_config(SPARK_DIR, JAVA_DIR, tmp_path, ComputeEnvironment.FAKE)
     config.binaries.spark_path = SPARK_DIR
     match sys.platform:
         case "linux":
@@ -152,10 +157,16 @@ def setup_local_env(tmp_path):
     config.binaries.hive_tarball = HIVE_DIR
     config.binaries.postgresql_jar_file = POSTGRES_JAR_FILE
     data = config.model_dump(mode="json", exclude={"directories"})
-    settings_file = tmp_path / DEFAULT_SETTINGS_FILENAME
-    with open(settings_file, "w", encoding="utf-8") as f_out:
-        toml.dump(data, f_out)
-    os.environ["ROOT_PATH_FOR_DYNACONF"] = str(tmp_path)
-    yield config, tmp_path
-    os.environ.pop("ROOT_PATH_FOR_DYNACONF")
-    shutil.rmtree(tmp_path)
+    # Inject the configuration into the Dynaconf singleton so that the CLI and
+    # make_default_spark_config() use it instead of any real ~/.sparkctl.toml. The singleton is
+    # built at import time, so setting an environment variable here would not take effect.
+    originals = {key: sparkctl_settings.get(key) for key in ("BINARIES", "RUNTIME", "COMPUTE")}
+    sparkctl_settings.set("BINARIES", data["binaries"])
+    sparkctl_settings.set("RUNTIME", data["runtime"])
+    sparkctl_settings.set("COMPUTE", data["compute"])
+    try:
+        yield config, tmp_path
+    finally:
+        for key, value in originals.items():
+            sparkctl_settings.set(key, value)
+        shutil.rmtree(tmp_path, ignore_errors=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,9 +26,9 @@ HADOOP_URL = f"https://archive.apache.org/dist/hadoop/common/{HADOOP_DIR_NAME}/{
 HADOOP_DIR_GZ = Path("tests") / "data" / HADOOP_GZ_NAME
 HADOOP_DIR = Path("tests") / "data" / HADOOP_DIR_NAME
 
-HIVE_DIR_NAME = "apache-hive-4.0.1-bin"
+HIVE_DIR_NAME = "apache-hive-4.2.0-bin"
 HIVE_GZ_NAME = f"{HIVE_DIR_NAME}.tar.gz"
-HIVE_URL = f"https://archive.apache.org/dist/hive/hive-4.0.1/{HIVE_GZ_NAME}"
+HIVE_URL = f"https://archive.apache.org/dist/hive/hive-4.2.0/{HIVE_GZ_NAME}"
 HIVE_DIR_GZ = Path("tests") / "data" / HIVE_GZ_NAME
 HIVE_DIR = Path("tests") / "data" / HIVE_DIR_NAME
 

--- a/tests/test_cluster_manager.py
+++ b/tests/test_cluster_manager.py
@@ -3,6 +3,7 @@ import time
 from pathlib import Path
 
 import psutil
+import pytest
 
 from sparkctl import (
     ClusterManager,
@@ -21,6 +22,7 @@ def test_cluster_manager_workers(setup_local_env: tuple[SparkConfig, Path]):
     assert mgr.get_workers() == new_workers
 
 
+@pytest.mark.integration
 def test_managed_start(setup_local_env: tuple[SparkConfig, Path]):
     config, output_dir = setup_local_env
     config.directories.base = output_dir

--- a/tests/test_slurm_compute.py
+++ b/tests/test_slurm_compute.py
@@ -1,16 +1,20 @@
 import os
+from pathlib import Path
 
 import pytest
 
-from sparkctl import make_default_spark_config
-from sparkctl.models import ComputeEnvironment
+from sparkctl.models import BinaryLocations, ComputeEnvironment, ComputeParams, SparkConfig
 from sparkctl.slurm_compute import SlurmCompute
 
 
 @pytest.fixture
 def slurm_compute() -> SlurmCompute:
-    config = make_default_spark_config()
-    config.compute.environment = ComputeEnvironment.SLURM
+    # Construct the config directly rather than through make_default_spark_config() so that the
+    # test does not depend on a user settings file (~/.sparkctl.toml), which is absent in CI.
+    config = SparkConfig(
+        binaries=BinaryLocations(spark_path=Path("spark"), java_path=Path("java")),
+        compute=ComputeParams(environment=ComputeEnvironment.SLURM),
+    )
     return SlurmCompute(config)
 
 

--- a/tests/test_spark_process_runner.py
+++ b/tests/test_spark_process_runner.py
@@ -1,0 +1,231 @@
+import os
+import signal
+import subprocess
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from sparkctl.exceptions import ExecutionError
+from sparkctl.models import (
+    BinaryLocations,
+    ComputeEnvironment,
+    ComputeParams,
+    RuntimeDirectories,
+    SparkConfig,
+)
+from sparkctl.spark_process_runner import SparkProcessRunner
+
+
+SPARK_URL = "spark://node1:7077"
+
+
+def make_config(
+    tmp_path: Path, environment: ComputeEnvironment, use_srun: bool = True
+) -> SparkConfig:
+    config = SparkConfig(
+        compute=ComputeParams(environment=environment, use_srun=use_srun),
+        binaries=BinaryLocations(spark_path=tmp_path / "spark", java_path=tmp_path / "java"),
+        directories=RuntimeDirectories(base=tmp_path, spark_scratch=tmp_path / "spark_scratch"),
+    )
+    config.directories.get_spark_conf_dir().mkdir()
+    return config
+
+
+class FakePopen:
+    def __init__(self, cmd, returncode=None, **kwargs):
+        self.cmd = cmd
+        self.pid = 12345
+        self._returncode = returncode
+
+    def poll(self):
+        return self._returncode
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+
+def test_start_worker_processes_srun(tmp_path, monkeypatch, no_sleep):
+    config = make_config(tmp_path, ComputeEnvironment.SLURM)
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["proc"] = FakePopen(cmd, **kwargs)
+        return captured["proc"]
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    monkeypatch.delenv("SLURM_HET_SIZE", raising=False)
+    runner = SparkProcessRunner(config, SPARK_URL)
+    runner.start_worker_processes(["node1", "node2"], 80, num_cpus_per_worker=104)
+
+    cmd = captured["proc"].cmd
+    assert cmd[0] == "srun"
+    assert "--nodes=2" in cmd
+    assert "--ntasks=2" in cmd
+    assert "--ntasks-per-node=1" in cmd
+    assert "--nodelist=node1,node2" in cmd
+    assert "--cpus-per-task=104" in cmd
+    assert not any(x.startswith("--het-group") for x in cmd)
+
+    content = Path(cmd[-1]).read_text(encoding="utf-8")
+    assert "export SPARK_NO_DAEMONIZE=true" in content
+    assert f"exec {config.binaries.spark_path}/sbin/start-worker.sh {SPARK_URL} -m 80g" in content
+
+    pid_file = config.directories.base / "srun_workers.pid"
+    assert pid_file.read_text(encoding="utf-8").strip() == "12345"
+
+
+def test_start_worker_processes_srun_heterogeneous(tmp_path, monkeypatch, no_sleep):
+    config = make_config(tmp_path, ComputeEnvironment.SLURM)
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["proc"] = FakePopen(cmd, **kwargs)
+        return captured["proc"]
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    monkeypatch.setenv("SLURM_HET_SIZE", "2")
+    runner = SparkProcessRunner(config, SPARK_URL)
+    runner.start_worker_processes(["node2", "node3"], 80)
+
+    cmd = captured["proc"].cmd
+    assert "--het-group=1" in cmd
+    assert not any(x.startswith("--nodelist") for x in cmd)
+    assert not any(x.startswith("--cpus-per-task") for x in cmd)
+
+
+def test_start_worker_processes_srun_immediate_failure(tmp_path, monkeypatch, no_sleep):
+    config = make_config(tmp_path, ComputeEnvironment.SLURM)
+    monkeypatch.setattr(subprocess, "Popen", lambda cmd, **kwargs: FakePopen(cmd, returncode=1))
+    runner = SparkProcessRunner(config, SPARK_URL)
+    with pytest.raises(ExecutionError):
+        runner.start_worker_processes(["node1", "node2"], 80)
+    assert not (config.directories.base / "srun_workers.pid").exists()
+
+
+def test_start_worker_processes_native_uses_ssh(tmp_path, monkeypatch):
+    config = make_config(tmp_path, ComputeEnvironment.NATIVE)
+    commands = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    runner = SparkProcessRunner(config, SPARK_URL)
+    runner.start_worker_processes(["node1", "node2"], 80)
+
+    assert len(commands) == 2
+    assert [cmd[0] for cmd in commands] == ["ssh", "ssh"]
+    assert [cmd[1] for cmd in commands] == ["node1", "node2"]
+
+
+def test_start_worker_processes_slurm_use_srun_disabled_uses_ssh(tmp_path, monkeypatch):
+    config = make_config(tmp_path, ComputeEnvironment.SLURM, use_srun=False)
+    commands = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        return SimpleNamespace(returncode=0)
+
+    def fail_popen(cmd, **kwargs):
+        msg = "srun must not be used when compute.use_srun is disabled"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(subprocess, "Popen", fail_popen)
+    runner = SparkProcessRunner(config, SPARK_URL)
+    runner.start_worker_processes(["node1", "node2"], 80, num_cpus_per_worker=104)
+
+    assert [cmd[0] for cmd in commands] == ["ssh", "ssh"]
+    assert not (config.directories.base / "srun_workers.pid").exists()
+
+
+def test_stop_worker_processes_slurm_use_srun_disabled_uses_ssh(tmp_path, monkeypatch):
+    config = make_config(tmp_path, ComputeEnvironment.SLURM, use_srun=False)
+    commands = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    runner = SparkProcessRunner(config, SPARK_URL)
+    assert runner.stop_worker_processes(["node1", "node2"]) == 0
+    assert [cmd[0] for cmd in commands] == ["ssh", "ssh"]
+
+
+def test_stop_worker_processes_srun(tmp_path, monkeypatch, no_sleep):
+    config = make_config(tmp_path, ComputeEnvironment.SLURM)
+    pid_file = config.directories.base / "srun_workers.pid"
+    pid_file.write_text("12345\n", encoding="utf-8")
+    kill_calls = []
+
+    def fake_kill(pid, sig):
+        kill_calls.append((pid, sig))
+        if sig == 0:
+            raise ProcessLookupError
+
+    def fake_waitpid(pid, flags):
+        raise ChildProcessError
+
+    monkeypatch.setattr(os, "kill", fake_kill)
+    monkeypatch.setattr(os, "waitpid", fake_waitpid)
+    runner = SparkProcessRunner(config, SPARK_URL)
+    assert runner.stop_worker_processes(["node1", "node2"]) == 0
+    assert (12345, signal.SIGTERM) in kill_calls
+    assert not pid_file.exists()
+
+
+def test_stop_worker_processes_srun_missing_pid_file(tmp_path):
+    config = make_config(tmp_path, ComputeEnvironment.SLURM)
+    runner = SparkProcessRunner(config, SPARK_URL)
+    assert runner.stop_worker_processes(["node1", "node2"]) == 1
+
+
+def test_stop_worker_processes_srun_stops_rmon(tmp_path, monkeypatch, no_sleep):
+    config = make_config(tmp_path, ComputeEnvironment.SLURM)
+    config.resource_monitor.enabled = True
+    pid_file = config.directories.base / "srun_workers.pid"
+    pid_file.write_text("12345\n", encoding="utf-8")
+
+    captured = {}
+    kill_order = []
+
+    def fake_run(cmd, **kwargs):
+        # Record the rmon-stop command and the generated script before it is unlinked.
+        captured["cmd"] = cmd
+        captured["script"] = Path(cmd[-1]).read_text(encoding="utf-8")
+        kill_order.append("stop_rmon_srun")
+        return SimpleNamespace(returncode=0)
+
+    def fake_kill(pid, sig):
+        if sig == signal.SIGTERM:
+            kill_order.append("kill_worker_srun")
+        elif sig == 0:
+            raise ProcessLookupError
+
+    def fake_waitpid(pid, flags):
+        raise ChildProcessError
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(os, "kill", fake_kill)
+    monkeypatch.setattr(os, "waitpid", fake_waitpid)
+    monkeypatch.delenv("SLURM_HET_SIZE", raising=False)
+
+    runner = SparkProcessRunner(config, SPARK_URL)
+    assert runner.stop_worker_processes(["node1", "node2"]) == 0
+
+    cmd = captured["cmd"]
+    assert cmd[0] == "srun"
+    assert "--overlap" in cmd
+    assert "--nodelist=node1,node2" in cmd
+    assert "kill -TERM" in captured["script"]
+    assert "rmon_$(hostname).pid" in captured["script"]
+    # rmon must be stopped before the worker job step is torn down.
+    assert kill_order == ["stop_rmon_srun", "kill_worker_srun"]
+    assert not pid_file.exists()
+    assert not (config.directories.get_spark_conf_dir() / "tmp_stop_rmon.sh").exists()

--- a/tests/test_spark_process_runner.py
+++ b/tests/test_spark_process_runner.py
@@ -38,6 +38,7 @@ class FakePopen:
         self.cmd = cmd
         self.pid = 12345
         self._returncode = returncode
+        self.kwargs = kwargs
 
     def poll(self):
         return self._returncode
@@ -69,6 +70,9 @@ def test_start_worker_processes_srun(tmp_path, monkeypatch, no_sleep):
     assert "--nodelist=node1,node2" in cmd
     assert "--cpus-per-task=104" in cmd
     assert not any(x.startswith("--het-group") for x in cmd)
+    # The background srun must not read the terminal, or it steals the interactive shell's input.
+    assert "--input=none" in cmd
+    assert captured["proc"].kwargs["stdin"] == subprocess.DEVNULL
 
     content = Path(cmd[-1]).read_text(encoding="utf-8")
     assert "export SPARK_NO_DAEMONIZE=true" in content
@@ -198,6 +202,7 @@ def test_stop_worker_processes_srun_stops_rmon(tmp_path, monkeypatch, no_sleep):
     def fake_run(cmd, **kwargs):
         # Record the rmon-stop command and the generated script before it is unlinked.
         captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
         captured["script"] = Path(cmd[-1]).read_text(encoding="utf-8")
         kill_order.append("stop_rmon_srun")
         return SimpleNamespace(returncode=0)
@@ -223,6 +228,8 @@ def test_stop_worker_processes_srun_stops_rmon(tmp_path, monkeypatch, no_sleep):
     assert cmd[0] == "srun"
     assert "--overlap" in cmd
     assert "--nodelist=node1,node2" in cmd
+    assert "--input=none" in cmd
+    assert captured["kwargs"]["stdin"] == subprocess.DEVNULL
     assert "kill -TERM" in captured["script"]
     assert "rmon_$(hostname).pid" in captured["script"]
     # rmon must be stopped before the worker job step is torn down.

--- a/tests/test_sparkctl_cli.py
+++ b/tests/test_sparkctl_cli.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import toml
 from click.testing import CliRunner
 
@@ -10,6 +11,7 @@ import sparkctl
 from sparkctl.cli.sparkctl import cli
 
 
+@pytest.mark.integration
 def test_default_config(tmp_path, spark_binaries):
     spark_path = spark_binaries[0]["dir_path"]
     hadoop_path = spark_binaries[1]["dir_path"]
@@ -46,6 +48,7 @@ def test_default_config(tmp_path, spark_binaries):
     assert data["binaries"]["postgresql_jar_file"] == str(postgres_jar.absolute())
 
 
+@pytest.mark.integration
 def test_configure_start_stop(setup_local_env):
     config, tmp_path = setup_local_env
     cmd = [


### PR DESCRIPTION
## Summary

Use `srun` instead of `ssh` to launch and stop multi-node Spark workers in Slurm environments, and fix the CI test suite along the way.

### `srun` for Slurm workers
- Start/stop multi-node workers via a long-lived `srun` job step instead of bare `ssh`. Unlike `ssh`, `srun` forwards the full submission environment (environment modules, virtual environments, `LD_LIBRARY_PATH`) to the worker nodes, so workers find shared libraries such as a shared `libpython` without manual `spark.executorEnv` tweaks. Non-Slurm (`native`) environments keep using `ssh`.
- Workers run in the foreground of the step (`SPARK_NO_DAEMONIZE`) because Slurm kills daemonized processes when the step ends; stopping the workers terminates that `srun`.
- New `compute.use_srun` option (default `true`) falls back to `ssh` for sites whose Slurm configuration does not work with sparkctl's `srun` invocation.
- When the resource monitor is enabled, rmon is stopped gracefully via an overlapping `srun` step **before** the worker job step is torn down, so it can flush its stats/plots and clean up its pid files.

### CI fixes
The CI suite was failing for three independent reasons, now all addressed:
1. **`ZeroDivisionError`** in executor sizing when a node has fewer CPUs than `executor_cores` (e.g. a 4-core runner with the default `executor_cores=5`). Guarded with `max(1, ...)` — a real bug that also affected `native` mode on small machines.
2. **Machine-dependent resource math** — added a `fake` compute environment with deterministic CPU/memory and use it in unit tests so results don't depend on the runner.
3. **Dependence on a real `~/.sparkctl.toml`** (absent in CI) — the `setup_local_env` fixture now injects the test config into the Dynaconf singleton, and the slurm-compute tests build their config directly.

Tests that download real binaries or boot a real cluster are quarantined behind a new `integration` marker; CI runs `pytest -m "not integration"` and the large downloads are skipped in that mode.

### Docs and dependencies
- Added a **Development** section to the README documenting how to run the unit vs. integration tests.
- Fixed broken download URLs to use permanent archive hosts (`archive.apache.org`, Oracle `java/21/archive`) instead of latest-only mirrors that 404 on pinned versions.
- Upgraded Hive from 4.0.1 to 4.2.0.

## Testing
- Unit suite under CI conditions (empty `HOME`, no user settings file): **16 passed, 3 deselected**.
- Integration tests locally (real clusters booted): **3 passed**.
- mypy, ruff, and pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)